### PR TITLE
Fix: escape special characters in file names

### DIFF
--- a/script.js
+++ b/script.js
@@ -1709,10 +1709,16 @@ class PDFConverterPro {
                         <p>${this.formatFileSize(result.size)}</p>
                     </div>
                 </div>
-                <button class="download-btn" onclick="window.pdfConverter.downloadResult('${result.url}', '${result.name}')">
+                <button class="download-btn" data-url="${result.url}" data-filename="${result.name}">
                     <i class="fas fa-download"></i> Download
                 </button>
             `;
+
+            resultItem.querySelector('.download-btn').addEventListener('click', (e) => {
+                const downloadBtn = e.currentTarget;
+                window.pdfConverter.downloadResult(downloadBtn.dataset.url, downloadBtn.dataset.filename);
+            });
+
             resultsList.appendChild(resultItem);
         });
 


### PR DESCRIPTION
This PR resolves an issue where file names containing special characters (like apostrophes) would break the download functionality by causing JavaScript string injection.